### PR TITLE
chore(deps-python): update dependency typer to >=0.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "bandit[toml]>=1.9.3",
     "cryptography>=46.0.5",
     "rich>=14.3.3",
-    "typer>=0.23.2",
+    "typer>=0.24.0",
     "yamllint>=1.38.0",
     "pip-audit>=2.10.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -75,7 +75,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.5" },
     { name = "rich", specifier = ">=14.3.3" },
     { name = "ruff", specifier = ">=0.15.2" },
-    { name = "typer", specifier = ">=0.23.2" },
+    { name = "typer", specifier = ">=0.24.0" },
     { name = "types-requests", specifier = ">=2.32.4.20260107" },
     { name = "yamllint", specifier = ">=1.38.0" },
 ]
@@ -1084,7 +1084,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.23.2"
+version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1092,9 +1092,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/93d16574e66dfe4c2284ffdaca4b0320ade32858cb2cc586c8dd79f127c5/typer-0.23.2.tar.gz", hash = "sha256:a99706a08e54f1aef8bb6a8611503808188a4092808e86addff1828a208af0de", size = 120162, upload-time = "2026-02-16T18:52:40.354Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/2c/dee705c427875402200fe779eb8a3c00ccb349471172c41178336e9599cc/typer-0.23.2-py3-none-any.whl", hash = "sha256:e9c8dc380f82450b3c851a9b9d5a0edf95d1d6456ae70c517d8b06a50c7a9978", size = 56834, upload-time = "2026-02-16T18:52:39.308Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
renovate/minor-updates-(twice-weekly) ブランチに存在した typer 更新コミットを、デフォルトブランチ修正作業の際に取りこぼさないよう cherry-pick したものです。

- typer: >=0.23.2 → >=0.24.0 (resolved: 0.24.1)
- uv.lock を最新状態に合わせて再生成