### PR TITLE
fix(ci): Security Scan を必須運用できるよう修正

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -22,7 +22,7 @@
   - 品質基準未達時のマージブロック
 
 ### 3. セキュリティスキャン (`security-scan.yml`)
-- **トリガー**: push (main, develop), pull_request, 定期実行 (毎週月曜日午前3時)
+- **トリガー**: pull_request (main, develop), 手動実行 (`workflow_dispatch`)
 - **実行内容**:
   - CodeQL セキュリティ分析
   - 依存関係脆弱性スキャン (pip-audit)

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv venv --python 3.13
+          uv venv --python 3.14
           uv sync
 
       - name: Run security scan
@@ -170,7 +170,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv venv --python 3.13
+          uv venv --python 3.14
           uv sync
 
       - name: Generate SBOM
@@ -180,6 +180,7 @@ jobs:
           uv run pip-audit --format cyclonedx-json --output security_reports/sbom.json
           status=$?
           set -e
+          # pip-audit returns 1 when vulnerabilities are detected; treat it as non-fatal for SBOM generation.
           if [ "$status" -gt 1 ]; then
             echo "SBOM generation failed while executing pip-audit."
             exit "$status"
@@ -189,7 +190,7 @@ jobs:
         run: |
           if [ -f security_reports/sbom.json ]; then
             echo 'SBOM generated successfully.'
-            jq '.metadata.timestamp // "timestamp unavailable"' security_reports/sbom.json
+            jq '.metadata.timestamp? // "timestamp unavailable"' security_reports/sbom.json
           else
             echo 'SBOM generation failed.'
             exit 1

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,6 +1,8 @@
 name: Security Scan
 
 on:
+  pull_request:
+    branches: [main, develop]
   workflow_dispatch:
     inputs:
       scan_type:
@@ -19,9 +21,9 @@ jobs:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     if: >
-      github.event_name == 'workflow_dispatch' &&
-      (github.event.inputs.scan_type == 'comprehensive' ||
-       github.event.inputs.scan_type == 'codeql-only')
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.scan_type == 'comprehensive' ||
+      github.event.inputs.scan_type == 'codeql-only'
     permissions:
       actions: read
       contents: read
@@ -61,9 +63,9 @@ jobs:
     name: Application Security Scan
     runs-on: ubuntu-latest
     if: >
-      github.event_name == 'workflow_dispatch' &&
-      (github.event.inputs.scan_type == 'comprehensive' ||
-       github.event.inputs.scan_type == 'security-only')
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.scan_type == 'comprehensive' ||
+      github.event.inputs.scan_type == 'security-only'
     permissions:
       contents: read
       security-events: write
@@ -117,9 +119,9 @@ jobs:
     name: Secret Scanning
     runs-on: ubuntu-latest
     if: >
-      github.event_name == 'workflow_dispatch' &&
-      (github.event.inputs.scan_type == 'comprehensive' ||
-       github.event.inputs.scan_type == 'security-only')
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.scan_type == 'comprehensive' ||
+      github.event.inputs.scan_type == 'security-only'
     permissions:
       contents: read
       security-events: write
@@ -134,6 +136,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_CONFIG: .gitleaks.toml
 
       - name: Run TruffleHog
         uses: trufflesecurity/trufflehog@v3.93.3
@@ -145,9 +148,9 @@ jobs:
     name: SBOM Generation
     runs-on: ubuntu-latest
     if: >
-      github.event_name == 'workflow_dispatch' &&
-      (github.event.inputs.scan_type == 'comprehensive' ||
-       github.event.inputs.scan_type == 'sbom-only')
+      github.event_name != 'workflow_dispatch' ||
+      github.event.inputs.scan_type == 'comprehensive' ||
+      github.event.inputs.scan_type == 'sbom-only'
     permissions:
       contents: read
       actions: read
@@ -171,13 +174,22 @@ jobs:
           uv sync
 
       - name: Generate SBOM
-        run: uv run python scripts/security_scan.py --scan-type=sbom
+        run: |
+          mkdir -p security_reports
+          set +e
+          uv run pip-audit --format cyclonedx-json --output security_reports/sbom.json
+          status=$?
+          set -e
+          if [ "$status" -gt 1 ]; then
+            echo "SBOM generation failed while executing pip-audit."
+            exit "$status"
+          fi
 
       - name: Validate SBOM
         run: |
           if [ -f security_reports/sbom.json ]; then
             echo 'SBOM generated successfully.'
-            jq '.metadata.timestamp' security_reports/sbom.json
+            jq '.metadata.timestamp // "timestamp unavailable"' security_reports/sbom.json
           else
             echo 'SBOM generation failed.'
             exit 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+title = "Bulk Migrator gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Ignore synthetic secrets used in logger masking tests"
+paths = ['''^tests/(unit/)?test_logger\.py$''']


### PR DESCRIPTION
## 概要
Security Scan ワークフローを `workflow_dispatch` 専用から `pull_request` でも実行される構成に変更し、必須チェックとして扱えるようにしました。あわせて、失敗要因となっていた SBOM 生成ジョブの不整合を修正しています。

## 変更内容
- `security-scan.yml`
  - トリガーに `pull_request`（main, develop）を追加
  - 各ジョブの `if` 条件を PR 実行時にも動作するよう調整
  - SBOM 生成を `pip-audit --format cyclonedx-json` ベースへ修正
  - gitleaks に `.gitleaks.toml` を指定
- `.gitleaks.toml` を追加
  - logger テストファイル由来の合成ダミー値のみ allowlist 化
- `.github/WORKFLOWS.md` の Security Scan トリガー説明を現状に合わせて更新

## 目的
- Security Scan をブランチ保護/Ruleset の required status check に設定可能にする
- SBOM ジョブの恒常失敗を解消する
- Secret scanning のノイズを抑え、実運用で有効な検出を維持する

## 補足
PR作成後、CI と Copilot auto-review を 2分間隔・最大10分で監視し、レビューコメントには採否を明示して返信します。