### PR TITLE
fix(ci): run Security Scan after merge to main

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -22,7 +22,7 @@
   - 品質基準未達時のマージブロック
 
 ### 3. セキュリティスキャン (`security-scan.yml`)
-- **トリガー**: pull_request (main, develop), 手動実行 (`workflow_dispatch`)
+- **トリガー**: push (main, develop), pull_request (main, develop), 手動実行 (`workflow_dispatch`)
 - **実行内容**:
   - CodeQL セキュリティ分析
   - 依存関係脆弱性スキャン (pip-audit)

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,6 +1,8 @@
 name: Security Scan
 
 on:
+  push:
+    branches: [main, develop]
   pull_request:
     branches: [main, develop]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- add push trigger on main/develop to Security Scan workflow
- keep existing pull_request and workflow_dispatch triggers
- update workflow documentation accordingly

## Why
Security Scan was only running for pull requests/manual dispatch, so it did not run after merges to main.

## Validation
- YAML parsed successfully via uv run python -c ...yaml.safe_load(...)
