### PR TITLE
fix(security): exclude dummy test-secret fixtures

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,6 @@
+# Intentional dummy secret-like values are used in these unit tests
+# to verify masking behavior; keep exclusions tightly scoped.
+paths-ignore:
+  - "tests/unit/test_logger.py"
+  - "tests/unit/test_structured_logger.py"
+  - "tests/unit/test_config_manager.py"

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ codeql-results/
 *secret*
 *credential*
 *password*
+!.github/secret_scanning.yml
 .bulk_migrator_key
 config_hash.txt
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,5 +4,9 @@ title = "Bulk Migrator gitleaks configuration"
 useDefault = true
 
 [[allowlists]]
-description = "Ignore synthetic secrets used in logger masking tests"
-paths = ['''^tests/(unit/)?test_logger\.py$''']
+description = "Ignore synthetic secrets used in masking-related unit tests"
+paths = [
+  '''^tests/unit/test_logger\.py$''',
+  '''^tests/unit/test_structured_logger\.py$''',
+  '''^tests/unit/test_config_manager\.py$''',
+]


### PR DESCRIPTION
## Summary
- add .github/secret_scanning.yml with scoped paths-ignore for masking unit tests
- expand .gitleaks.toml allowlist for the same test files
- unignore .github/secret_scanning.yml in .gitignore so the config is versioned

## Context
Security tab secret-check findings appear to be dummy values in tests, so exclusions are narrowly scoped to those fixture-like files.

## Validation
- parsed TOML/YAML configs
- uv run pytest -q tests/unit/test_logger.py tests/unit/test_structured_logger.py tests/unit/test_config_manager.py (55 passed)